### PR TITLE
feat: allow custom nicknames and cleanup banner

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -31,14 +31,7 @@
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
     <div class="container" style="width: 95%; height: 100%">
       <div class="row" style="height: 100%">
-        <div class="one-third column" style="margin-top: 25%">
-          <h4><b>Chat</b>, powered by Durable Objects</h4>
-          <p>
-            This chat room is hosted in a single Durable Object, running in one
-            process in one machine in one location, very close to the users.
-          </p>
-        </div>
-        <div class="two-thirds column" id="root"></div>
+        <div class="twelve columns" id="root"></div>
       </div>
     </div>
 

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -10,10 +10,12 @@ import {
 } from "react-router";
 import { nanoid } from "nanoid";
 
-import { names, type ChatMessage, type Message } from "../shared";
+import { type ChatMessage, type Message } from "../shared";
 
 function App() {
-  const [name] = useState(names[Math.floor(Math.random() * names.length)]);
+  const [name, setName] = useState(
+    () => localStorage.getItem("nickname") || "",
+  );
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const { room } = useParams();
 
@@ -72,6 +74,21 @@ function App() {
 
   return (
     <div className="chat container">
+      <div className="row">
+        <input
+          type="text"
+          name="nickname"
+          className="twelve columns my-input-text"
+          placeholder="Enter your nickname"
+          value={name}
+          onChange={(e) => {
+            const value = e.target.value;
+            setName(value);
+            localStorage.setItem("nickname", value);
+          }}
+          autoComplete="off"
+        />
+      </div>
       {messages.map((message) => (
         <div key={message.id} className="row message">
           <div className="two columns user">{message.user}</div>
@@ -88,7 +105,7 @@ function App() {
           const chatMessage: ChatMessage = {
             id: nanoid(8),
             content: content.value,
-            user: name,
+            user: name || "Anonymous",
             role: "user",
           };
           setMessages((messages) => [...messages, chatMessage]);
@@ -108,10 +125,16 @@ function App() {
           type="text"
           name="content"
           className="ten columns my-input-text"
-          placeholder={`Hello ${name}! Type a message...`}
+          placeholder={
+            name ? `Hello ${name}! Type a message...` : "Type a message..."
+          }
           autoComplete="off"
         />
-        <button type="submit" className="send-message two columns">
+        <button
+          type="submit"
+          className="send-message two columns"
+          disabled={!name}
+        >
           Send
         </button>
       </form>


### PR DESCRIPTION
## Summary
- remove Durable Objects banner from landing page
- allow users to set and persist nicknames for chatting

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b45ae2b1dc832dac69ae7da2844cfc